### PR TITLE
[#44] 폴더 필터링 기능

### DIFF
--- a/src/main/java/com/umc/cardify/config/exception/ErrorResponseStatus.java
+++ b/src/main/java/com/umc/cardify/config/exception/ErrorResponseStatus.java
@@ -24,6 +24,7 @@ public enum ErrorResponseStatus {
 	DB_UPDATE_ERROR(4006, "DB에 값을 수정 하는데 실패 했습니다."),
 	FILE_FORMAT_ERROR(4007, "파일 형식 검증 실패"),
 	FILE_VALID_ERROR(4008,"파일 유효성 검증 실패" ),
+	NOT_EXIST_FOLDER(4009, "폴더가 존재하지 않습니다."),
 
 	// 5000 : Server connection 오류
 	SERVER_ERROR(5000, "서버와의 연결에 실패하였습니다."),

--- a/src/main/java/com/umc/cardify/controller/FolderController.java
+++ b/src/main/java/com/umc/cardify/controller/FolderController.java
@@ -102,7 +102,7 @@ public class FolderController {
     }
 
     @GetMapping("/filter")
-    @Operation(summary = "폴더 필터링 기능 API", description = "해당 유저의 폴더를 색상으로 필터링하여 반환 | filterType=color")
+    @Operation(summary = "폴더 필터링 기능 API", description = "해당 유저의 폴더를 색상으로 필터링하여 반환 | color값은 String으로 입력&반환")
     public ResponseEntity<FolderResponse.FolderListDTO> filterFolders(
             @RequestHeader("Authorization") String token,
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/com/umc/cardify/controller/FolderController.java
+++ b/src/main/java/com/umc/cardify/controller/FolderController.java
@@ -105,9 +105,9 @@ public class FolderController {
     @Operation(summary = "폴더 필터링 기능 API", description = "해당 유저의 폴더를 색상으로 필터링하여 반환 | color값은 String으로 입력&반환")
     public ResponseEntity<FolderResponse.FolderListDTO> filterFolders(
             @RequestHeader("Authorization") String token,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "5") int size,
-            @RequestParam(required = false) String color) {
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size,
+            @RequestParam String color) {
         Long userId = jwtUtil.extractUserId(token);
         FolderResponse.FolderListDTO folders = folderService.filterColorsByUserId(userId, page, size, color);
         return ResponseEntity.ok(folders);

--- a/src/main/java/com/umc/cardify/controller/FolderController.java
+++ b/src/main/java/com/umc/cardify/controller/FolderController.java
@@ -1,6 +1,5 @@
 package com.umc.cardify.controller;
 
-import com.umc.cardify.domain.Folder;
 import com.umc.cardify.dto.folder.FolderRequest;
 import com.umc.cardify.dto.folder.FolderResponse;
 import com.umc.cardify.dto.note.NoteResponse;
@@ -100,5 +99,17 @@ public class FolderController {
         Long userId = jwtUtil.extractUserId(token);
         FolderResponse.markFolderResultDTO response = folderService.markFolderById(userId, folderId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/filter")
+    @Operation(summary = "폴더 필터링 기능 API", description = "해당 유저의 폴더를 색상으로 필터링하여 반환 | filterType=color")
+    public ResponseEntity<FolderResponse.FolderListDTO> filterFolders(
+            @RequestHeader("Authorization") String token,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size,
+            @RequestParam(required = false) String color) {
+        Long userId = jwtUtil.extractUserId(token);
+        FolderResponse.FolderListDTO folders = folderService.filterColorsByUserId(userId, page, size, color);
+        return ResponseEntity.ok(folders);
     }
 }

--- a/src/main/java/com/umc/cardify/domain/Folder.java
+++ b/src/main/java/com/umc/cardify/domain/Folder.java
@@ -36,7 +36,6 @@ public class Folder extends BaseEntity {
     private MarkStatus markState;
 
     @UpdateTimestamp
-    @Column(name = "mark_date", columnDefinition = "varchar(15) NOT NULL")
     private Timestamp markDate;
 
     @UpdateTimestamp

--- a/src/main/java/com/umc/cardify/repository/FolderRepository.java
+++ b/src/main/java/com/umc/cardify/repository/FolderRepository.java
@@ -15,4 +15,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     Optional<Folder> findByFolderIdAndUser(Long folderId, User userId);
 
     boolean existsByUserAndName(User user, String name);
+
+    Page<Folder> findByUserAndColor(User user, String color, Pageable pageable);
+
 }

--- a/src/main/java/com/umc/cardify/repository/FolderRepository.java
+++ b/src/main/java/com/umc/cardify/repository/FolderRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,6 +20,11 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     boolean existsByUserAndName(User user, String name);
 
-    Page<Folder> findByUserAndColor(User user, String color, Pageable pageable);
-    List<Folder> findByUserAndColor(User user, String color, Sort sort);
+    @Query(value = "SELECT * FROM folder WHERE user_id = :userId AND color IN (:colors) ORDER BY " +
+            "CASE WHEN mark_state = 'ACTIVE' THEN 0 " +
+            "WHEN mark_state = 'INACTIVE' THEN 1 " +
+            "ELSE 2 END, " +
+            "mark_date ASC, created_at ASC", nativeQuery = true)
+    Page<Folder> findByUserAndColor(@Param("userId") Long userId, @Param("colors") String colors, Pageable pageable);
+
 }

--- a/src/main/java/com/umc/cardify/repository/FolderRepository.java
+++ b/src/main/java/com/umc/cardify/repository/FolderRepository.java
@@ -4,8 +4,10 @@ import com.umc.cardify.domain.Folder;
 import com.umc.cardify.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
@@ -17,5 +19,5 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     boolean existsByUserAndName(User user, String name);
 
     Page<Folder> findByUserAndColor(User user, String color, Pageable pageable);
-
+    List<Folder> findByUserAndColor(User user, String color, Sort sort);
 }

--- a/src/main/java/com/umc/cardify/service/FolderService.java
+++ b/src/main/java/com/umc/cardify/service/FolderService.java
@@ -182,7 +182,7 @@ public class FolderService {
         if (colors != null && !colors.isEmpty()) {
             folderPage = folderRepository.findByUserAndColor(user, colors, pageable);
             if (folderPage.isEmpty()) {
-                throw new BadRequestException(ErrorResponseStatus.NOT_EXIST_FOLDER);
+                throw new DatabaseException(ErrorResponseStatus.NOT_EXIST_FOLDER);
             }
         } else {
             throw new BadRequestException(ErrorResponseStatus.REQUEST_ERROR);

--- a/src/main/java/com/umc/cardify/service/FolderService.java
+++ b/src/main/java/com/umc/cardify/service/FolderService.java
@@ -176,7 +176,7 @@ public class FolderService {
     public FolderResponse.FolderListDTO filterColorsByUserId(Long userId, int page, int size, String colors){
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new BadRequestException(ErrorResponseStatus.REQUEST_ERROR));
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("markState"), Sort.Order.asc("name")));
         Page<Folder> folderPage;
 
         if (colors != null && !colors.isEmpty()) {


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #44  //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
-  입력된 색상 값(String)에 따라서 해당 색상 값을 가진 폴더가 추출
- 반환 값은 폴더 아이디, 폴더 이름, 폴더 색상, 폴더 즐겨찾기 유무, 폴더 생성일, 폴더 수정일
- 해당 컬러의 폴더가 없는 경우 NOT_EXIST_FOLDER 에러 처리(4009)
- 즐겨찾기 ACTIVE인 폴더는 정렬 상관없이 상단 고정되도록 구현(즐겨찾기 오래된 순으로 상단 고정)
- 페이징 처리 ---------> page, size 고정 처리 없이 전체 데이터 출력할 수 있게 변경(size는 한 페이지에 최대 30개)

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료

입력시 - page, size값은 고정 없이 결과에 대한 전체 데이터 출력
![스크린샷 2024-07-29 145914](https://github.com/user-attachments/assets/71ed9991-a3be-4d56-bf96-bccb4dd462d1)


성공 반환
![스크린샷 2024-07-29 145855](https://github.com/user-attachments/assets/67600a3c-8ba4-4db4-b972-92e6f89c4913)
![스크린샷 2024-07-29 145903](https://github.com/user-attachments/assets/e107db8e-5886-412d-80af-1c6c509f4079)

NOT_EXIST_FOLDER 반환
![스크린샷 2024-07-26 165826](https://github.com/user-attachments/assets/a1419781-7d33-49c3-8204-f88e45b1e328)

