### PR TITLE
[#53] 모든 폴더 조회 기능 수정

### DIFF
--- a/src/main/java/com/umc/cardify/controller/FolderController.java
+++ b/src/main/java/com/umc/cardify/controller/FolderController.java
@@ -25,11 +25,11 @@ public class FolderController {
     private final JwtUtil jwtUtil;
 
     @GetMapping
-    @Operation(summary = "폴더 목록 조회 API", description = "조회 성공 시, 해당 유저의 폴더 목록 반환")
+    @Operation(summary = "폴더 목록 조회 API", description = "조회 성공 시, 해당 유저의 폴더 목록 반환 | page, size는 수정 가능")
     public ResponseEntity<FolderResponse.FolderListDTO> getAllFolders(
             @RequestHeader("Authorization") String token,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam int size) {
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size) {
         Long userId = jwtUtil.extractUserId(token);
         FolderResponse.FolderListDTO folders = folderService.getFoldersByUserId(userId, page, size);
         return ResponseEntity.ok(folders);

--- a/src/main/java/com/umc/cardify/domain/Folder.java
+++ b/src/main/java/com/umc/cardify/domain/Folder.java
@@ -32,10 +32,11 @@ public class Folder extends BaseEntity {
     private String color;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(15) DEFAULT 'INACTIVE'")
+    @Column(name = "mark_sate", columnDefinition = "VARCHAR(15) DEFAULT 'INACTIVE'")
     private MarkStatus markState;
 
     @UpdateTimestamp
+    @Column(name = "mark_date")
     private Timestamp markDate;
 
     @UpdateTimestamp

--- a/src/main/java/com/umc/cardify/dto/folder/FolderRequest.java
+++ b/src/main/java/com/umc/cardify/dto/folder/FolderRequest.java
@@ -21,7 +21,7 @@ public class FolderRequest {
         @Schema(description = "폴더 이름", example = "sample")
         String name;
         @NotNull
-        @Schema(description = "폴더 색상", example = "red")
+        @Schema(description = "폴더 색상", example = "blue")
         String color;
     }
 
@@ -35,7 +35,7 @@ public class FolderRequest {
         @Schema(description = "폴더 이름", example = "sample1")
         String name;
         @NotNull
-        @Schema(description = "폴더 색상", example = "green")
+        @Schema(description = "폴더 색상", example = "blue")
         String color;
     }
 }

--- a/src/main/java/com/umc/cardify/dto/folder/FolderResponse.java
+++ b/src/main/java/com/umc/cardify/dto/folder/FolderResponse.java
@@ -20,9 +20,9 @@ public class FolderResponse {
         private Long folderId;
         @Schema(description = "폴더 이름", example = "Sample1")
         private String name;
-        @Schema(description = "폴더 색상", example = "red")
+        @Schema(description = "폴더 색상", example = "blue")
         private String color;
-        @Schema(description = "폴더 즐겨찾기", example = "ACTIVE")
+        @Schema(description = "폴더 즐겨찾기", example = "INACTIVE")
         private MarkStatus markState;
         @Schema(description = "폴더의 노트개수", example = "3")
         private Integer getNoteCount;
@@ -114,7 +114,7 @@ public class FolderResponse {
         Long folderId;
         @Schema(description = "폴더 이름", example = "sample")
         String name;
-        @Schema(description = "폴더 색상", example = "red")
+        @Schema(description = "폴더 색상", example = "blue")
         String color;
         @Schema(description = "폴더 생성 날짜", example = "2023-12-05 12:34:56")
         private LocalDateTime createdAt;
@@ -130,7 +130,7 @@ public class FolderResponse {
         Long folderId;
         @Schema(description = "폴더 이름", example = "sample")
         String name;
-        @Schema(description = "폴더 색상", example = "red")
+        @Schema(description = "폴더 색상", example = "ocean")
         String color;
         @Schema(description = "폴더 수정 날짜", example = "2023-12-05 12:34:56")
         Timestamp editDate;

--- a/src/main/java/com/umc/cardify/dto/folder/FolderResponse.java
+++ b/src/main/java/com/umc/cardify/dto/folder/FolderResponse.java
@@ -145,7 +145,7 @@ public class FolderResponse {
         @Schema(description = "즐겨찾기 성공 여부", example = "true")
         Boolean isSuccess;
         @Schema(description = "즐겨찾기 상태", example = "ACTIVE")
-        String markState;
+        MarkStatus markState;
         @Schema(description = "폴더 즐겨찾기 수정 날짜", example = "2023-12-05 12:34:56")
         Timestamp markDate;
     }

--- a/src/main/java/com/umc/cardify/repository/FolderRepository.java
+++ b/src/main/java/com/umc/cardify/repository/FolderRepository.java
@@ -14,7 +14,12 @@ import java.util.Optional;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
 
-    Page<Folder> findByUser(User userId, Pageable pageable);
+    @Query(value = "SELECT * FROM folder WHERE user_id = :userId ORDER BY " +
+            "CASE WHEN mark_state = 'ACTIVE' THEN 0 " +
+            "WHEN mark_state = 'INACTIVE' THEN 1 " +
+            "ELSE 2 END, " +
+            "mark_date ASC, created_at ASC", nativeQuery = true)
+    Page<Folder> findByUser(@Param("userId") User userId, Pageable pageable);
 
     Optional<Folder> findByFolderIdAndUser(Long folderId, User userId);
 
@@ -25,6 +30,6 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
             "WHEN mark_state = 'INACTIVE' THEN 1 " +
             "ELSE 2 END, " +
             "mark_date ASC, created_at ASC", nativeQuery = true)
-    Page<Folder> findByUserAndColor(@Param("userId") Long userId, @Param("colors") String colors, Pageable pageable);
+    Page<Folder> findByUserAndColor(@Param("userId") User userId, @Param("colors") String colors, Pageable pageable);
 
 }

--- a/src/main/java/com/umc/cardify/repository/FolderRepository.java
+++ b/src/main/java/com/umc/cardify/repository/FolderRepository.java
@@ -4,32 +4,27 @@ import com.umc.cardify.domain.Folder;
 import com.umc.cardify.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
 
-    @Query(value = "SELECT * FROM folder WHERE user_id = :userId ORDER BY " +
-            "CASE WHEN mark_state = 'ACTIVE' THEN 0 " +
-            "WHEN mark_state = 'INACTIVE' THEN 1 " +
-            "ELSE 2 END, " +
-            "mark_date ASC, created_at ASC", nativeQuery = true)
-    Page<Folder> findByUser(@Param("userId") User userId, Pageable pageable);
+    @Query("SELECT f FROM Folder f WHERE f.user = :user ORDER BY " +
+            "CASE WHEN f.markState = 'ACTIVE' THEN 0 ELSE 1 END, " +
+            "CASE WHEN f.markState = 'ACTIVE' THEN f.markDate ELSE f.createdAt END DESC, " +
+            "f.createdAt DESC ")
+    Page<Folder> findByUser(@Param("user") User user, Pageable pageable);
 
     Optional<Folder> findByFolderIdAndUser(Long folderId, User userId);
 
     boolean existsByUserAndName(User user, String name);
 
-    @Query(value = "SELECT * FROM folder WHERE user_id = :userId AND color IN (:colors) ORDER BY " +
-            "CASE WHEN mark_state = 'ACTIVE' THEN 0 " +
-            "WHEN mark_state = 'INACTIVE' THEN 1 " +
-            "ELSE 2 END, " +
-            "mark_date ASC, created_at ASC", nativeQuery = true)
-    Page<Folder> findByUserAndColor(@Param("userId") User userId, @Param("colors") String colors, Pageable pageable);
-
+    @Query("SELECT f FROM Folder f WHERE f.user = :user AND f.color IN (:color) ORDER BY " +
+            "CASE WHEN f.markState = 'ACTIVE' THEN 0 ELSE 1 END, " +
+            "CASE WHEN f.markState = 'ACTIVE' THEN f.markDate ELSE f.createdAt END DESC, " +
+            "f.createdAt DESC ")
+    Page<Folder> findByUserAndColor(@Param("user") User user, @Param("color") String color, Pageable pageable);
 }

--- a/src/main/java/com/umc/cardify/service/FolderService.java
+++ b/src/main/java/com/umc/cardify/service/FolderService.java
@@ -33,11 +33,21 @@ public class FolderService {
         return folderRepository.findById(folderId).orElseThrow(()-> new BadRequestException(ErrorResponseStatus.NOT_FOUND_ERROR));
     }
 
-    public FolderResponse.FolderListDTO getFoldersByUserId(Long userId, int page, int size){
+    @Transactional(readOnly = true)
+    public FolderResponse.FolderListDTO getFoldersByUserId(Long userId, Integer page, Integer size){
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
-        Pageable pageable = PageRequest.of(page, size);
+                .orElseThrow(() -> new BadRequestException(ErrorResponseStatus.INVALID_USERID));
+
+        // 폴더 page, size에 값을 입력하지 않으면, 자동으로 0과 30으로 고정
+        int getFolderPage = (page!=null) ? page:0;
+        int getFolderSize = (size!=null) ? size:30;
+
+        Pageable pageable = PageRequest.of(getFolderPage, getFolderSize);
         Page<Folder> folderPage = folderRepository.findByUser(user, pageable);
+
+        if(folderPage.isEmpty()){
+            throw new BadRequestException(ErrorResponseStatus.NOT_EXIST_FOLDER);
+        }
 
         List<FolderResponse.FolderInfoDTO> folders = folderPage.getContent().stream()
                 .map(folder -> FolderResponse.FolderInfoDTO.builder()
@@ -184,7 +194,7 @@ public class FolderService {
 
         if (colors != null && !colors.isEmpty()) {
             Pageable pageable = PageRequest.of(filterPage, filterSize);
-            Page<Folder> folderPage = folderRepository.findByUserAndColor(userId, colors, pageable);
+            Page<Folder> folderPage = folderRepository.findByUserAndColor(user, colors, pageable);
             folderList = folderPage.getContent();
         } else {
             throw new DatabaseException(ErrorResponseStatus.NOT_EXIST_FOLDER);
@@ -205,8 +215,8 @@ public class FolderService {
                         .build())
                 .collect(Collectors.toList());
 
-        int totalPages = (page == null) ? 1 : folderRepository.findByUserAndColor(userId, colors, Pageable.unpaged()).getTotalPages();
-        long totalElements = (page == null) ? folders.size() : folderRepository.findByUserAndColor(userId, colors, Pageable.unpaged()).getTotalElements();
+        int totalPages = (page == null) ? 1 : folderRepository.findByUserAndColor(user, colors, Pageable.unpaged()).getTotalPages();
+        long totalElements = (page == null) ? folders.size() : folderRepository.findByUserAndColor(user, colors, Pageable.unpaged()).getTotalElements();
 
         return FolderResponse.FolderListDTO.builder()
                 .foldersList(folders)

--- a/src/main/java/com/umc/cardify/service/FolderService.java
+++ b/src/main/java/com/umc/cardify/service/FolderService.java
@@ -56,6 +56,7 @@ public class FolderService {
                         .color(folder.getColor())
                         .markState(folder.getMarkState())
                         .getNoteCount(folder.getNoteCount())
+                        .markDate(folder.getMarkDate())
                         .editDate(folder.getEditDate())
                         .createdAt(folder.getCreatedAt())
                         .build())
@@ -177,7 +178,7 @@ public class FolderService {
         folderRepository.save(folder);
 
         return FolderResponse.markFolderResultDTO.builder()
-                .markState(folder.getMarkState().toString())
+                .markState(folder.getMarkState())
                 .isSuccess(true)
                 .markDate(folder.getMarkDate())
                 .build();


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #53  //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 즐겨찾기 폴더를 상단으로 고정하여 정렬
- 페이징 수정, 전체 페이지가 나올 수 있게끔 (page, size 제한 없음)

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야 할 부분을 작성해주세요! -->

## 📔 참고 자료
즐겨찾기가 ACTIVE되어있으면서 markDate를 기준으로 내림차순으로 폴더가 상단에 고정되고,
나머지 INACTIVE 혹은 null인 경우에는 createdAt을 기준으로 내림차순으로 정렬된다.

![image](https://github.com/user-attachments/assets/cf72c666-0afb-4d78-9bc0-bc48e2b79b19)
![image](https://github.com/user-attachments/assets/b26c14fc-53d0-4dbf-ae01-ca4ff3464c73)
