### PR TITLE
[#58] 폴더 정렬 기능 수정

### DIFF
--- a/src/main/java/com/umc/cardify/controller/FolderController.java
+++ b/src/main/java/com/umc/cardify/controller/FolderController.java
@@ -36,11 +36,11 @@ public class FolderController {
     }
 
     @GetMapping("/sort")
-    @Operation(summary = "폴더 정렬 기능 API", description = "해당 유저의 폴더를 정렬해서 반환, 페이징을 포함 query string으로 페이지 번호를 주세요. | order = asc, desc, edit-newest, edit-oldest")
+    @Operation(summary = "폴더 정렬 기능 API", description = "성공 시 해당 유저의 폴더를 정렬해서 반환 | order = asc, desc, edit-newest, edit-oldest")
     public ResponseEntity<FolderResponse.sortFolderListDTO> sortFolders(
             @RequestHeader("Authorization") String token,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam int size,
+            @RequestParam(required = false)  Integer page,
+            @RequestParam(required = false)  Integer size,
             @RequestParam String order){
         Long userId = jwtUtil.extractUserId(token);
         FolderResponse.sortFolderListDTO folders = folderService.sortFoldersByUserId(userId, page, size, order);

--- a/src/main/java/com/umc/cardify/repository/FolderRepository.java
+++ b/src/main/java/com/umc/cardify/repository/FolderRepository.java
@@ -14,9 +14,20 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     @Query("SELECT f FROM Folder f WHERE f.user = :user ORDER BY " +
             "CASE WHEN f.markState = 'ACTIVE' THEN 0 ELSE 1 END, " +
-            "CASE WHEN f.markState = 'ACTIVE' THEN f.markDate ELSE f.createdAt END DESC, " +
-            "f.createdAt DESC ")
+            "f.markDate ASC, f.createdAt DESC ")
     Page<Folder> findByUser(@Param("user") User user, Pageable pageable);
+
+    @Query("SELECT f FROM Folder f WHERE f.user = :user ORDER BY " +
+            "CASE WHEN f.markState = 'ACTIVE' THEN 0 ELSE 1 END, " +
+            "CASE WHEN f.markState = 'ACTIVE' THEN f.markDate END ASC, " +
+            "CASE WHEN :order = 'asc' THEN f.name " +
+            "WHEN :order = 'edit-oldest' THEN f.editDate " +
+            "END ASC, " +
+            "CASE WHEN :order = 'desc' THEN f.name " +
+            "WHEN :order = 'edit-newest' THEN f.editDate " +
+            "END DESC")
+    Page<Folder> findByUserAndSort(@Param("user") User user, @Param("order") String order, Pageable pageable);
+
 
     Optional<Folder> findByFolderIdAndUser(Long folderId, User userId);
 
@@ -24,7 +35,6 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     @Query("SELECT f FROM Folder f WHERE f.user = :user AND f.color IN (:color) ORDER BY " +
             "CASE WHEN f.markState = 'ACTIVE' THEN 0 ELSE 1 END, " +
-            "CASE WHEN f.markState = 'ACTIVE' THEN f.markDate ELSE f.createdAt END DESC, " +
-            "f.createdAt DESC ")
+            "f.markDate ASC, f.createdAt DESC ")
     Page<Folder> findByUserAndColor(@Param("user") User user, @Param("color") String color, Pageable pageable);
 }

--- a/src/main/java/com/umc/cardify/service/FolderService.java
+++ b/src/main/java/com/umc/cardify/service/FolderService.java
@@ -15,10 +15,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -73,18 +73,26 @@ public class FolderService {
                 .build();
     }
 
-    public FolderResponse.sortFolderListDTO sortFoldersByUserId(Long userId, int page, int size, String order){
+    public FolderResponse.sortFolderListDTO sortFoldersByUserId(Long userId, Integer page, Integer size, String order){
         User user = userRepository.findById(userId)
-                .orElseThrow(()-> new IllegalArgumentException("User not found with id: " + userId));
-        Pageable pageable = switch (order.toLowerCase()) {
-            case "asc" -> PageRequest.of(page, size, Sort.by("name").ascending());
-            case "desc" -> PageRequest.of(page, size, Sort.by("name").descending());
-            case "edit-newest" -> PageRequest.of(page, size, Sort.by("editDate").ascending());
-            case "edit-oldest" -> PageRequest.of(page, size, Sort.by("editDate").descending());
-            default -> throw new BadRequestException(ErrorResponseStatus.REQUEST_ERROR);
-        };
+                .orElseThrow(()-> new BadRequestException(ErrorResponseStatus.INVALID_USERID));
 
-        Page<Folder> folderPage = folderRepository.findByUser(user, pageable);
+        int sortFolderPage = (page!=null) ? page:0;
+        int sortFolderSize = (size!=null) ? size:30;
+
+        switch(order){
+            case "asc":
+            case "desc":
+            case "edit-newest":
+            case "edit-oldest":
+                break;
+            default:
+                throw new BadRequestException(ErrorResponseStatus.REQUEST_ERROR);
+        }
+
+        Pageable pageable = PageRequest.of(sortFolderPage, sortFolderSize);
+        Page<Folder> folderPage = folderRepository.findByUserAndSort(user, order, pageable);
+
         List<FolderResponse.sortFolderInfoDTO> folders = folderPage.getContent().stream()
                 .map(folder -> FolderResponse.sortFolderInfoDTO.builder()
                         .folderId(folder.getFolderId())


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #58   //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 즐겨찾기 상단 고정과 정렬 기능 쿼리 수정
- 페이징 제한 없음(page, size 값 없이 전체 데이터 출력)

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료

상단의 8, 5, 6 폴더는 즐겨찾기되어있는 상단고정 폴더임
아래의 7, 9 폴더가 즐겨찾기가 안되어서 정렬에 영향을 받는 폴더


정렬 : 폴더 이름 오름차순
![스크린샷 2024-08-03 215215](https://github.com/user-attachments/assets/f1edb5ed-1bc4-4716-a0c2-698852855ce6)

정렬: 폴더 이름 내림차순
![스크린샷 2024-08-03 215301](https://github.com/user-attachments/assets/13411b92-c138-476a-a37a-2d80434a9087)

정렬 : 폴더 수정일 내림차순
![스크린샷 2024-08-03 215315](https://github.com/user-attachments/assets/c0e30295-c5ee-46ca-ac16-96a4274bcd94)

정렬 : 폴더 수정일 오름차순
![스크린샷 2024-08-03 215325](https://github.com/user-attachments/assets/8b6565df-9812-45ae-97bd-1eca19a4f815)
