### PR TITLE
[#85] 특정 폴더 내 노트 삭제 기능 추가

### DIFF
--- a/src/main/java/com/umc/cardify/config/exception/ErrorResponseStatus.java
+++ b/src/main/java/com/umc/cardify/config/exception/ErrorResponseStatus.java
@@ -24,9 +24,9 @@ public enum ErrorResponseStatus {
 	DB_UPDATE_ERROR(4006, "DB에 값을 수정 하는데 실패 했습니다."),
 	FILE_FORMAT_ERROR(4007, "파일 형식 검증 실패"),
 	FILE_VALID_ERROR(4008,"파일 유효성 검증 실패" ),
-	NOT_EXIST_FOLDER(4009, "폴더가 존재하지 않습니다."),
+	NOT_EXIST_FOLDER(4009, "해당 폴더가 존재하지 않습니다."),
 	NOT_FOUND_CATEGORY(4010, "해당 카테고리는 존재하지 않습니다."),
-	NOT_EXIST_NOTE(4011, "노트가 존재하지 않습니다."),
+	NOT_EXIST_NOTE(4011, "해당 노트가 존재하지 않습니다."),
 
 	// 5000 : Server connection 오류
 	SERVER_ERROR(5000, "서버와의 연결에 실패하였습니다.");

--- a/src/main/java/com/umc/cardify/controller/FolderController.java
+++ b/src/main/java/com/umc/cardify/controller/FolderController.java
@@ -113,4 +113,15 @@ public class FolderController {
         FolderResponse.FolderListDTO folders = folderService.filterColorsByUserId(userId, page, size, color);
         return ResponseEntity.ok(folders);
     }
+
+    @DeleteMapping("/{folderId}/notes/{noteId}")
+    @Operation(summary = "특정 폴더 내 노트 삭제 기능 API", description = "특정 폴더 안의 특정 노트를 삭제하는 기능 | 폴더 아이디와 노트 아이디를 request로 요청하고 삭제 성공 시, boolean 값으로 도출")
+    public ResponseEntity<NoteResponse.IsSuccessNoteDTO> deleteNoteByFolder(
+            @RequestHeader("Authorization") String token,
+            @PathVariable Long folderId,
+            @PathVariable Long noteId) {
+        Long userId = jwtUtil.extractUserId(token);
+        NoteResponse.IsSuccessNoteDTO response = folderService.deleteNoteByFolderId(userId, folderId, noteId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/umc/cardify/repository/NoteRepository.java
+++ b/src/main/java/com/umc/cardify/repository/NoteRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
@@ -21,4 +22,6 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
            "n.markAt ASC, n.createdAt DESC ")
     Page<Note> findByUser(@Param("user") User user, Pageable pageable);
     void deleteByFolder(Folder folder);
+
+    Optional<Note> findByNoteIdAndFolder(Long noteId, Folder folder);
 }

--- a/src/main/java/com/umc/cardify/service/FolderService.java
+++ b/src/main/java/com/umc/cardify/service/FolderService.java
@@ -4,10 +4,12 @@ import com.umc.cardify.config.exception.BadRequestException;
 import com.umc.cardify.config.exception.DatabaseException;
 import com.umc.cardify.config.exception.ErrorResponseStatus;
 import com.umc.cardify.domain.Folder;
+import com.umc.cardify.domain.Note;
 import com.umc.cardify.domain.User;
 import com.umc.cardify.domain.enums.MarkStatus;
 import com.umc.cardify.dto.folder.FolderRequest;
 import com.umc.cardify.dto.folder.FolderResponse;
+import com.umc.cardify.dto.note.NoteResponse;
 import com.umc.cardify.repository.FolderRepository;
 import com.umc.cardify.repository.NoteRepository;
 import com.umc.cardify.repository.UserRepository;
@@ -236,6 +238,23 @@ public class FolderService {
                 .totalElements(totalElements)
                 .isFirst(filterPage == 0)
                 .isLast((page == null) || (filterPage == totalPages - 1))
+                .build();
+    }
+
+    @Transactional
+    public NoteResponse.IsSuccessNoteDTO deleteNoteByFolderId(Long userId, Long folderId, Long noteId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BadRequestException(ErrorResponseStatus.INVALID_USERID));
+        Folder folder = folderRepository.findByFolderIdAndUser(folderId, user)
+                .orElseThrow(() -> new BadRequestException(ErrorResponseStatus.NOT_EXIST_FOLDER));
+        Note note = noteRepository.findByNoteIdAndFolder(noteId, folder)
+                .orElseThrow(() -> new BadRequestException(
+                        ErrorResponseStatus.NOT_EXIST_NOTE));
+
+        noteRepository.delete(note);
+
+        return NoteResponse.IsSuccessNoteDTO.builder()
+                .isSuccess(true)
                 .build();
     }
 }


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #85  //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 기능 : 특정 폴더의 아이디와 노트 아이디를 입력하면 삭제
- 에러 : 특정 폴더의 아이디에 해당하는 노트만 삭제 --> 아니면 Error반환

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료

삭제를 성공한 경우
![스크린샷 2024-08-09 111521](https://github.com/user-attachments/assets/76e7ba09-0b73-4634-b744-f099a44d0934)
![스크린샷 2024-08-09 111542](https://github.com/user-attachments/assets/b7d3df19-403a-4ab5-b062-d33a98feede0)
