### PR TITLE
[#138] 대시보드 최근 열람 노트 조회 기능

### DIFF
--- a/src/main/java/com/umc/cardify/controller/NoteController.java
+++ b/src/main/java/com/umc/cardify/controller/NoteController.java
@@ -95,4 +95,14 @@ public class NoteController {
     public ResponseEntity<NoteResponse.getNoteDTO> getNote(@RequestParam @Valid Long noteId){
         return ResponseEntity.ok(noteComponentService.getNote(noteId));
     }
+    @GetMapping("/recent-notes")
+    @Operation(summary = "최신 열람 노트 조회 API", description = "사용자의 최신 열람 노트 4개/3개 반환")
+    public ResponseEntity<List<NoteResponse.NoteInfoDTO>> gerRecentNote(
+            @RequestHeader("Authorization") String token,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false) Integer size) {
+        Long userId = jwtUtil.extractUserId(token);
+        List<NoteResponse.NoteInfoDTO> notes = noteComponentService.getRecentNotes(userId, page, size);
+        return ResponseEntity.ok(notes);
+    }
 }

--- a/src/main/java/com/umc/cardify/converter/NoteConverter.java
+++ b/src/main/java/com/umc/cardify/converter/NoteConverter.java
@@ -84,4 +84,18 @@ public class NoteConverter {
                 .textList(textList)
                 .build();
     }
+    public NoteResponse.NoteInfoDTO recentNoteInfoDTO(Note note) {
+        return NoteResponse.NoteInfoDTO.builder()
+                .noteId(note.getNoteId())
+                .name(note.getName())
+                .folderId(note.getFolder().getFolderId())
+                .folderColor(note.getFolder().getColor())
+                .folderName(note.getFolder().getName())
+                .viewAt(note.getViewAt())
+                .editDate(note.getEditDate().toLocalDateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .createdAt(note.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .isDownload(note.getDownloadLibId() != null)
+                .isUpload(libraryService.isUploadLib(note))
+                .build();
+    }
 }

--- a/src/main/java/com/umc/cardify/dto/note/NoteResponse.java
+++ b/src/main/java/com/umc/cardify/dto/note/NoteResponse.java
@@ -40,6 +40,8 @@ public class NoteResponse {
         private String folderColor;
         @Schema(description = "노트 즐겨찾기", example = "ACTIVE")
         private MarkStatus markState;
+        @Schema(description = "노트 열람일", example = "2023-07-18")
+        private LocalDateTime viewAt;
         @Schema(description = "노트 수정일", example = "2023-07-18")
         private String editDate;
         @Schema(description = "노트 생성 날짜", example = "2023-07-10")

--- a/src/main/java/com/umc/cardify/repository/NoteRepository.java
+++ b/src/main/java/com/umc/cardify/repository/NoteRepository.java
@@ -39,4 +39,8 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
             "CASE WHEN :order = 'desc' THEN n.name END DESC, " +
             "CASE WHEN :order = 'edit-newest' THEN n.editDate END DESC")
     Page<Note> findByUserAndSort(@Param("user") User user, @Param("order") String order, Pageable pageable); // 전체 노트 정렬 - 아카이브
+
+    @Query("SELECT n FROM Note n WHERE n.folder.user = :user ORDER BY " +
+            "n.viewAt DESC ")
+    Page<Note> findByUserOrderByViewAtDesc(User user, Pageable pageable);
 }

--- a/src/main/java/com/umc/cardify/service/NoteComponentService.java
+++ b/src/main/java/com/umc/cardify/service/NoteComponentService.java
@@ -373,4 +373,15 @@ public class NoteComponentService {
 			.isLast(notePage.isLast())
 			.build();
 	}
+
+	public List<NoteResponse.NoteInfoDTO> getRecentNotes(Long userId, int page, Integer size) {
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new BadRequestException(ErrorResponseStatus.INVALID_USERID));
+		int recentNoteSize = (size != null) ? size : 5;
+		Pageable pageable = PageRequest.of(page, recentNoteSize);
+		Page<Note> notes = noteRepository.findByUserOrderByViewAtDesc(user,pageable);
+		return notes.stream()
+				.map(noteConverter::recentNoteInfoDTO)
+				.collect(Collectors.toList());
+	}
 }


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #138 

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 최근 열람일(viewAt) 순으로 노트 리스트 반환
- 페이징 처리는 없음 최대 사이즈는 5이므로, 화면 크기에 따라 3 or 4로 조회하면됨

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료

viewAt이 최신 순으로 정렬되어 조회됨
페이징은 0부터 시작하고 size에는 화면 크기에 맞춰서 3혹은 4로 설정하여 요청하면됨
![image](https://github.com/user-attachments/assets/57ba3f52-48b3-4cbc-bab5-f115b9e92b0e)
![image](https://github.com/user-attachments/assets/bf9cdcab-bea2-48b4-b333-8600cd347063)
