### PR TITLE
[#204] 상위/하위 폴더 조회/정렬/필터링 API 수정

### DIFF
--- a/src/main/java/com/umc/cardify/controller/FolderController.java
+++ b/src/main/java/com/umc/cardify/controller/FolderController.java
@@ -28,12 +28,13 @@ public class FolderController {
     @Operation(summary = "폴더 정렬과 필터링 기능 API", description = "성공 시 해당 유저의 폴더를 정렬 혹은 필터링해서 반환, 아무것도 입력 안하면 일반 조회 기능 | 정렬 order = asc, desc, edit-newest, edit-oldest | 필터링 쉼표로 구분된 색상 문자열 입력")
     public ResponseEntity<FolderResponse.FolderListDTO> foldersBySortFilter(
             @RequestHeader("Authorization") String token,
+            @RequestParam(required = false) Long parentFolderId,
             @RequestParam(required = false)  Integer page,
             @RequestParam(required = false)  Integer size,
             @RequestParam(required = false) String order,
             @RequestParam(required = false) String color){
         Long userId = jwtUtil.extractUserId(token);
-        FolderResponse.FolderListDTO folders = folderService.getFoldersBySortFilter(userId, page, size, order, color);
+        FolderResponse.FolderListDTO folders = folderService.getFoldersBySortFilter(userId, parentFolderId, page, size, order, color);
         return ResponseEntity.ok(folders);
     }
 
@@ -78,7 +79,7 @@ public class FolderController {
     public ResponseEntity<FolderResponse.addFolderResultDTO> addSubFolder(
             @RequestHeader("Authorization") String token,
             @PathVariable Long folderId,
-            @RequestBody @Valid FolderRequest.addFolderDto subFolderRequest) {
+            @RequestBody @Valid FolderRequest.addSubFolderDto subFolderRequest) {
         Long userId = jwtUtil.extractUserId(token);
         FolderResponse.addFolderResultDTO response = folderService.addSubFolder(userId, subFolderRequest, folderId);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/src/main/java/com/umc/cardify/dto/folder/FolderRequest.java
+++ b/src/main/java/com/umc/cardify/dto/folder/FolderRequest.java
@@ -38,4 +38,16 @@ public class FolderRequest {
         @Schema(description = "폴더 색상", example = "기존 색상")
         String color;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "FOLDER_REQ_03 : 하위 폴더 추가 요청 DTO")
+    public static class addSubFolderDto{
+        @NotBlank
+        @Schema(description = "폴더 이름", example = "sample")
+        String name;
+    }
+
 }

--- a/src/main/java/com/umc/cardify/repository/FolderRepository.java
+++ b/src/main/java/com/umc/cardify/repository/FolderRepository.java
@@ -36,4 +36,8 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     // 사용자의 폴더 개수를 count
     int countByUserAndParentFolderIsNull(User user);
+
+    List<Folder> findByUserAndParentFolderIsNull(User user);
+
+    List<Folder> findByParentFolderAndUser(Folder parentFolder, User user);
 }

--- a/src/main/java/com/umc/cardify/service/FolderService.java
+++ b/src/main/java/com/umc/cardify/service/FolderService.java
@@ -38,73 +38,39 @@ public class FolderService {
         return folderRepository.findById(folderId).orElseThrow(()-> new BadRequestException(ErrorResponseStatus.NOT_FOUND_ERROR));
     }
 
-    // 폴더 조회, 정렬, 필터링 Service
+    // 상위/하위 폴더 조회, 정렬, 필터링
     @Transactional
-    public FolderResponse.FolderListDTO getFoldersBySortFilter(Long userId, Integer page, Integer size, String order, String color){
+    public FolderResponse.FolderListDTO getFoldersBySortFilter(Long userId, Long parentFolderId, Integer page, Integer size, String order, String color) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BadRequestException(ErrorResponseStatus.INVALID_USERID));
 
         int folderPage = (page != null) ? page : 0;
         int folderSize = (size != null) ? size : Integer.MAX_VALUE;
 
+        List<Folder> folders;
 
-        // color와 order가 입력되지 않은 경우, 일반 조회 기능으로 실행
-        if ((color == null || color.isEmpty()) && (order == null || order.isEmpty())) {
-            Pageable pageable = PageRequest.of(folderPage, folderSize);
-            Page<Folder> folderPageResult = folderRepository.findByUser(user, pageable);
-
-            if (folderPageResult.isEmpty()) {
-                throw new BadRequestException(ErrorResponseStatus.NOT_EXIST_FOLDER);
-            }
-
-            List<FolderResponse.FolderInfoDTO> folders = folderPageResult.getContent().stream()
-                    .map(folder -> {
-                        Note latestNote = noteRepository.findTopByFolderOrderByEditDateDesc(folder);
-                        Timestamp latestNoteEditDate = latestNote != null ? latestNote.getEditDate() : null;
-
-                        if (latestNoteEditDate != null) {
-                            if (folder.getEditDate() == null || latestNoteEditDate.after(folder.getEditDate())) {
-                                folder.setEditDate(latestNoteEditDate);
-                                folderRepository.save(folder); //비교해서 가장 최신 수정일로 저장함
-                            }
-                        }
-
-                        return FolderResponse.FolderInfoDTO.builder()
-                                .folderId(folder.getFolderId())
-                                .name(folder.getName())
-                                .color(folder.getColor())
-                                .markState(folder.getMarkState())
-                                .getNoteCount(folder.getNoteCount())
-                                .markDate(folder.getMarkDate())
-                                .editDate(folder.getEditDate())
-                                .createdAt(folder.getCreatedAt())
-                                .build();
-                    })
-                    .collect(Collectors.toList());
-
-            return FolderResponse.FolderListDTO.builder()
-                    .foldersList(folders)
-                    .listSize(folderPageResult.getSize())
-                    .currentPage(folderPageResult.getNumber() + 1)
-                    .totalPages(folderPageResult.getTotalPages())
-                    .totalElements(folderPageResult.getNumberOfElements())
-                    .isFirst(folderPageResult.isFirst())
-                    .isLast(folderPageResult.isLast())
-                    .build();
+        // 1. 상위 폴더와 하위 폴더를 구분하여 기본 폴더 리스트 가져오기
+        if (parentFolderId == null) {
+            // 상위 폴더 조회
+            folders = folderRepository.findByUserAndParentFolderIsNull(user);
+        } else {
+            // 하위 폴더 조회
+            Folder parentFolder = folderRepository.findById(parentFolderId)
+                    .orElseThrow(() -> new BadRequestException(ErrorResponseStatus.NOT_EXIST_FOLDER));
+            folders = folderRepository.findByParentFolderAndUser(parentFolder, user);
         }
 
-        //색상 필터링
-        List<Folder> filteredFolders = filterFoldersByColor(user, color);
+        // 2. 색상 필터 적용
+        List<Folder> filteredFolders = filterFoldersByColor(folders, color);
 
-        //이름,수정일 정렬
+        // 3. 정렬 적용
         List<Folder> sortedFolders = sortFolders(filteredFolders, order);
 
-        //페이징 처리
+        // 4. 페이징 적용
         List<Folder> pagedFolders = pagingFolders(sortedFolders, folderPage, folderSize);
 
-        //정렬 시, 반환 데이터
+        // 5. FolderListDTO 생성
         List<FolderResponse.FolderInfoDTO> foldersInfo = convertToFolderInfoDTOs(pagedFolders);
-
         int totalElements = sortedFolders.size();
         int totalPages = (totalElements + folderSize - 1) / folderSize;
 
@@ -118,50 +84,56 @@ public class FolderService {
                 .isLast(folderPage == totalPages - 1)
                 .build();
     }
-    private List<Folder> filterFoldersByColor(User user, String colors) {
+
+    private List<Folder> filterFoldersByColor(List<Folder> folders, String colors) {
         if (colors == null || colors.isEmpty()) {
-            return folderRepository.findByUser(user);
+            return folders;
         }
 
         List<String> colorList = Arrays.asList(colors.split(","));
         List<String> allowedColors = Arrays.asList("blue", "ocean", "lavender", "mint", "sage", "gray", "orange", "coral", "rose", "plum");
 
-        for (String c : colorList) {
-            if (!allowedColors.contains(c)) {
+        colorList.forEach(color -> {
+            if (!allowedColors.contains(color)) {
                 throw new BadRequestException(ErrorResponseStatus.REQUEST_ERROR);
             }
-        }
-        return folderRepository.findByUserAndColor(user, colorList);
+        });
+
+        return folders.stream()
+                .filter(folder -> colorList.contains(folder.getColor()))
+                .collect(Collectors.toList());
     }
+
     private List<Folder> sortFolders(List<Folder> folders, String order) {
         if (order == null || order.isEmpty()) {
             return folders;
         }
+
         List<String> orderList = Arrays.asList("asc", "desc", "edit-newest", "edit-oldest");
         if (!orderList.contains(order)) {
             throw new BadRequestException(ErrorResponseStatus.REQUEST_ERROR);
         }
+
         return folders.stream()
-                .sorted(new FolderComparator(order)
-                        .thenComparing(Folder::getFolderId))
+                .sorted(new FolderComparator(order).thenComparing(Folder::getFolderId))
                 .collect(Collectors.toList());
     }
+
     private List<Folder> pagingFolders(List<Folder> folders, int page, int size) {
         int start = page * size;
         int end = Math.min((page + 1) * size, folders.size());
         return folders.subList(start, end);
     }
+
     private List<FolderResponse.FolderInfoDTO> convertToFolderInfoDTOs(List<Folder> folders) {
         return folders.stream()
                 .map(folder -> {
                     Note latestNote = noteRepository.findTopByFolderOrderByEditDateDesc(folder);
                     Timestamp latestNoteEditDate = latestNote != null ? latestNote.getEditDate() : null;
 
-                    if (latestNoteEditDate != null) {
-                        if (folder.getEditDate() == null || latestNoteEditDate.after(folder.getEditDate())) {
-                            folder.setEditDate(latestNoteEditDate);
-                            folderRepository.save(folder); //비교해서 가장 최신 수정일로 저장함
-                        }
+                    if (latestNoteEditDate != null && (folder.getEditDate() == null || latestNoteEditDate.after(folder.getEditDate()))) {
+                        folder.setEditDate(latestNoteEditDate);
+                        folderRepository.save(folder);
                     }
 
                     return FolderResponse.FolderInfoDTO.builder()
@@ -222,7 +194,7 @@ public class FolderService {
 
     //하위 폴더 생성
     @Transactional
-    public FolderResponse.addFolderResultDTO addSubFolder(Long userId, FolderRequest.addFolderDto subFolderRequest, Long folderId) {
+    public FolderResponse.addFolderResultDTO addSubFolder(Long userId, FolderRequest.addSubFolderDto subFolderRequest, Long folderId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new BadRequestException(ErrorResponseStatus.INVALID_USERID));
 
@@ -238,7 +210,7 @@ public class FolderService {
         Folder newSubFolder = Folder.builder()
                 .user(user)
                 .name(subFolderRequest.getName())
-                .color(subFolderRequest.getColor())
+                .color(parentFolder.getColor())
                 .markState(MarkStatus.INACTIVE)
                 .parentFolder(parentFolder)
                 .build();


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #204 

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 상위/하위 폴더 조회/정렬/필터링 API 수정 : 상위 폴더 페이지에서 조회할 때, 하위 폴더 아이디가 반환 되지 않도록(반대도 마찬가지)

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
