### PR TITLE
[#222] 빠른 학습 탭 - 카드셋 진도율 반환과 예정(만기) 학습 정렬

### DIFF
--- a/src/main/java/com/umc/cardify/controller/CardController.java
+++ b/src/main/java/com/umc/cardify/controller/CardController.java
@@ -184,4 +184,18 @@ public class CardController {
 
 		return ResponseEntity.ok(studyDateDTO);
 	}
+
+	@GetMapping("/quick-learning")
+	@Operation(summary = "빠른 학습 탭 - 플래시 카드 세트 조회",
+			description = "사용자에게 학습 시간 도달한 카드가 있는 StudyCardSet을 최대 3개 반환")
+	public ResponseEntity<List<CardResponse.getExpectedCardSetListDTO>> getQuickLearningStudySets(
+			@RequestHeader("Authorization") String token) {
+		String email = jwtTokenProvider.getEmailFromToken(token.replace("Bearer ", ""));
+		Long userId = userRepository.findByEmail(email)
+				.orElseThrow(() -> new BadRequestException(ErrorResponseStatus.INVALID_USERID))
+				.getUserId();
+
+		List<CardResponse.getExpectedCardSetListDTO> sets = cardComponentService.getStudyCardSetsForQuickLearning(userId);
+		return ResponseEntity.ok(sets);
+	}
 }

--- a/src/main/java/com/umc/cardify/domain/StudyCardSet.java
+++ b/src/main/java/com/umc/cardify/domain/StudyCardSet.java
@@ -70,6 +70,12 @@ public class StudyCardSet extends BaseEntity {
 	@Column(name = "next_study_date")
 	private LocalDateTime nextStudyDate;
 
+	@Column(name = "completed_cards_count")
+	private int completedCardsCount;
+
+	@Column(name = "cards_due_for_study")
+	private int cardsDueForStudy;
+
 	@OneToMany(mappedBy = "studyCardSet", cascade = CascadeType.REMOVE)
 	private List<ImageCard> imageCards;
 
@@ -88,5 +94,10 @@ public class StudyCardSet extends BaseEntity {
 	public void setFolderInfo(Folder folder) {
 		this.folder = folder;
 		this.color = folder.getColor();
+	}
+
+	// 진도율 계산 헬퍼 메소드
+	public double getProgressRate() {
+		return cardsDueForStudy == 0 ? 0.0 : (double) completedCardsCount / cardsDueForStudy;
 	}
 }

--- a/src/main/java/com/umc/cardify/dto/card/CardResponse.java
+++ b/src/main/java/com/umc/cardify/dto/card/CardResponse.java
@@ -190,4 +190,21 @@ public class CardResponse {
 		@Schema(description = "학습 예상 날짜")
 		List<Integer> expectedDate;
 	}
+
+	@Getter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Schema(title = "CARD_RES_09 : 홈화면 - 카드셋 진도율 반환 DTO")
+	public static class getExpectedCardSetListDTO {
+		Long studyCardSetId;
+		String folderName;
+		String noteName;
+		String color;
+		int cardsDueForStudy;
+		int completedCardsCount;
+		double progressRate;
+		LocalDateTime recentStudyDate;
+		LocalDateTime nextStudyDate;
+	}
 }

--- a/src/main/java/com/umc/cardify/repository/StudyCardSetRepository.java
+++ b/src/main/java/com/umc/cardify/repository/StudyCardSetRepository.java
@@ -3,12 +3,12 @@ package com.umc.cardify.repository;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.umc.cardify.domain.Note;
 import com.umc.cardify.domain.StudyCardSet;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StudyCardSetRepository extends JpaRepository<StudyCardSet, Long> {
 
@@ -18,4 +18,6 @@ public interface StudyCardSetRepository extends JpaRepository<StudyCardSet, Long
 
 	boolean existsByNote(Note note);
 
+	@Query("SELECT s FROM StudyCardSet s WHERE s.user.userId = :userId ORDER BY s.nextStudyDate ASC")
+	List<StudyCardSet> findByUserOrderByNextStudyDateAsc(@Param("userId") Long userId);
 }

--- a/src/main/java/com/umc/cardify/service/CardComponentService.java
+++ b/src/main/java/com/umc/cardify/service/CardComponentService.java
@@ -804,5 +804,28 @@ public class CardComponentService {
 		}
 		return weekResult;
 	}
+
+	public List<CardResponse.getExpectedCardSetListDTO> getStudyCardSetsForQuickLearning(Long userId) {
+		List<StudyCardSet> studyCardSets = studyCardSetRepository.findByUserOrderByNextStudyDateAsc(userId);
+
+		studyCardSets = studyCardSets.stream()
+				.filter(set -> set.getProgressRate() < 1.0)
+				.limit(3)
+				.collect(Collectors.toList());
+
+		return studyCardSets.stream()
+				.map(set -> CardResponse.getExpectedCardSetListDTO.builder()
+						.studyCardSetId(set.getId())
+						.folderName(set.getFolder() != null ? set.getFolder().getName() : null)
+						.noteName(set.getNoteName())
+						.color(set.getColor())
+						.cardsDueForStudy(set.getCardsDueForStudy())
+						.completedCardsCount(set.getCompletedCardsCount())
+						.progressRate(set.getProgressRate())
+						.recentStudyDate(set.getRecentStudyDate())
+						.nextStudyDate(set.getNextStudyDate())
+						.build())
+				.collect(Collectors.toList());
+	}
 }
 


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #222 

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- studyCardSet 엔티티 변경 (card_due_for_study, completed_cards_count, 진도율 계산 헬퍼 메소드)
- 진도율(1.0은 완료 학습 카드셋) 최대 3개 조회

## 피드백 참고 사항
- 카드 '재학습' 기능 사용시, studyCardSet이 삭제되기때문에 진도율 리셋은 필요 없음

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
![Image](https://github.com/user-attachments/assets/d95ceff1-bb41-43de-81ef-a1280fb842b8)
![Image](https://github.com/user-attachments/assets/d678355e-f80b-41de-965f-5831fffb62ed)
