### PR TITLE
[#227] : 결제 엔티티 생성으로 인한 구독 여부에 따른 폴더 생성 기능 수정

### DIFF
--- a/src/main/java/com/umc/cardify/domain/User.java
+++ b/src/main/java/com/umc/cardify/domain/User.java
@@ -51,9 +51,6 @@ public class User extends BaseEntity {
     @Setter
     private Integer point = 5000;
 
-    @Column(name = "subscribe")
-    private boolean subscribe = false;
-
     @Column(name = "today_check")
     @Setter
     private int todayCheck = 0;

--- a/src/main/java/com/umc/cardify/service/FolderService.java
+++ b/src/main/java/com/umc/cardify/service/FolderService.java
@@ -6,6 +6,7 @@ import com.umc.cardify.domain.Folder;
 import com.umc.cardify.domain.Note;
 import com.umc.cardify.domain.User;
 import com.umc.cardify.domain.enums.MarkStatus;
+import com.umc.cardify.domain.enums.SubscriptionStatus;
 import com.umc.cardify.dto.folder.FolderComparator;
 import com.umc.cardify.dto.folder.FolderRequest;
 import com.umc.cardify.dto.folder.FolderResponse;
@@ -162,9 +163,12 @@ public class FolderService {
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new BadRequestException(ErrorResponseStatus.INVALID_USERID));
 
+        boolean isSubscribed = user.getSubscriptions().stream()
+                .anyMatch(subscription -> subscription.getStatus() == SubscriptionStatus.ACTIVE);
+
         // 유료 결제 여부에 따른 상위 폴더 개수 제한
         int folderCount = folderRepository.countByUserAndParentFolderIsNull(user);
-        if (!user.isSubscribe() && folderCount >= 9) { // 무료 사용자 제한
+        if (!isSubscribed && folderCount >= 9) { // 무료 사용자 제한
             throw new BadRequestException(ErrorResponseStatus.FOLDER_CREATED_NOT_ALLOWED);
         }
 
@@ -205,8 +209,11 @@ public class FolderService {
             throw new BadRequestException(ErrorResponseStatus.SUBFOLDER_CREATION_NOT_ALLOWED);
         }
 
+        boolean isSubscribed = user.getSubscriptions().stream()
+                .anyMatch(subscription -> subscription.getStatus() == SubscriptionStatus.ACTIVE);
+
         // 유료 결제 여부에 따른 하위 폴더 개수 제한
-        if (!user.isSubscribe() && subFolderCount >= 9) { // 무료 사용자 제한
+        if (!isSubscribed && subFolderCount >= 9) { // 무료 사용자 제한
             throw new BadRequestException(ErrorResponseStatus.SUBFOLDER_CREATION_NOT_ALLOWED);
         }
 


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #227 

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 사용자 엔티티의 subscribe 속성 삭제 -> 결제 엔티티 생성으로 인한 엔티티 수정
- 구독 여부에 따른 상위/하위 폴더 생성의 구독 여부 접근 속성 수정

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [ ] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
