### PR TITLE
[236] 날짜 및 시간 반환 형식 수정

### DIFF
--- a/src/main/java/com/umc/cardify/converter/NoteConverter.java
+++ b/src/main/java/com/umc/cardify/converter/NoteConverter.java
@@ -49,6 +49,7 @@ public class NoteConverter {
                 .folderName(note.getFolder().getName())
                 .markState(note.getMarkState())
                 .flashCardCount(note.getCards() != null ? (long) note.getCards().size() : 0L)
+                .markAt(note.getMarkAt().toLocalDate().format(DateTimeFormatter.ofPattern("yy/MM/dd")))
                 .editDate(note.getEditDate().toLocalDateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
                 .createdAt(note.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
                 .isDownload(note.getDownloadLibId() != null)

--- a/src/main/java/com/umc/cardify/dto/folder/FolderResponse.java
+++ b/src/main/java/com/umc/cardify/dto/folder/FolderResponse.java
@@ -1,5 +1,6 @@
 package com.umc.cardify.dto.folder;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.umc.cardify.domain.enums.MarkStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -26,11 +27,14 @@ public class FolderResponse {
         private MarkStatus markState;
         @Schema(description = "폴더의 노트개수", example = "3")
         private Integer getNoteCount;
-        @Schema(description = "폴더 즐겨찾기 수정 날짜", example = "2023-12-05 12:34:56")
+        @Schema(description = "폴더 즐겨찾기 수정 날짜", example = "2023/12/05")
+        @JsonFormat(pattern= "yy/MM/dd")
         private Timestamp markDate;
-        @Schema(description = "폴더 수정 날짜", example = "2023-12-05 12:34:56")
+        @Schema(description = "폴더 수정 날짜", example = "2023/12/05")
+        @JsonFormat(pattern= "yy/MM/dd")
         private Timestamp editDate;
-        @Schema(description = "폴더 생성 날짜", example = "2023-12-05 12:34:56")
+        @Schema(description = "폴더 생성 날짜", example = "2023/12/05")
+        @JsonFormat(pattern= "yy/MM/dd", timezone = "Asia/Seoul")
         private LocalDateTime createdAt;
     }
 
@@ -80,7 +84,7 @@ public class FolderResponse {
         private String name;
         @Schema(description = "폴더 색상", example = "blue")
         private String color;
-        @Schema(description = "폴더 생성 날짜", example = "2023-12-05 12:34:56")
+        @Schema(description = "폴더 생성 날짜", example = "2023/12/05")
         private LocalDateTime createdAt;
     }
 
@@ -96,7 +100,7 @@ public class FolderResponse {
         String name;
         @Schema(description = "폴더 색상", example = "ocean")
         String color;
-        @Schema(description = "폴더 수정 날짜", example = "2023-12-05 12:34:56")
+        @Schema(description = "폴더 수정 날짜", example = "2023/12/05")
         Timestamp editDate;
     }
 

--- a/src/main/java/com/umc/cardify/dto/note/NoteResponse.java
+++ b/src/main/java/com/umc/cardify/dto/note/NoteResponse.java
@@ -45,6 +45,8 @@ public class NoteResponse {
         private Long flashCardCount;
         @Schema(description = "노트 열람일", example = "2023-07-18")
         private LocalDateTime viewAt;
+        @Schema(description = "노트 즐겨찾기 날짜", example = "yy/MM/dd")
+        private String markAt;
         @Schema(description = "노트 수정일", example = "2023-07-18")
         private String editDate;
         @Schema(description = "노트 생성 날짜", example = "2023-07-10")


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #236 

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 폴더와 노트 날짜 반환 형식 수정(JsonFormat어노테이션과 DateTimeFormatter를 사용함)

## ✔️ 체크 리스트
- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
**아카이브 화면의 폴더 날짜 형식 yy/MM/dd**
![image](https://github.com/user-attachments/assets/69c4c278-ab48-4ade-b45e-c8fa70d5d92d)

**아카이브 화면의 노트 날짜 형식 yy-MM-dd**
![image](https://github.com/user-attachments/assets/3e1d2d13-d245-4c43-a4c7-4b33f812b129)

**홈화면의 폴더/노트 즐겨찾기 최신순 날짜 형식 yy/MM/dd**
![image](https://github.com/user-attachments/assets/0d390368-3172-48f4-b39d-30f25999f4a3)

